### PR TITLE
feat:redux 기본 셋팅 및 api 데이터 불러오는 기능 추가

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,13 +2,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { GlobalStyle } from './styled';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { authstore } from './store/authstore';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-    <>
+    <Provider store={authstore}>
         <GlobalStyle />
         <BrowserRouter>
             <App />
         </BrowserRouter>
-    </>,
+    </Provider>,
 );

--- a/client/src/store/authstore.tsx
+++ b/client/src/store/authstore.tsx
@@ -1,0 +1,14 @@
+import { configureStore } from '@reduxjs/toolkit';
+import dataReducer from '../slice/authslice';
+
+export const authstore = configureStore({
+    reducer: {
+        data: dataReducer,
+    },
+});
+
+export type AppDispatch = typeof authstore.dispatch;
+export type RootState = ReturnType<typeof authstore.getState>;
+
+//import { RootState } from '../store/authstore';
+//import type { AppDispatch } from '../store/authstore';

--- a/client/src/styled.tsx
+++ b/client/src/styled.tsx
@@ -9,4 +9,9 @@ export const GlobalStyle = createGlobalStyle`
         font-family:'';
     }
 
+    a {
+        color: inherit;
+        text-decoration: none;
+    }
+
 `;


### PR DESCRIPTION
body:store 및 slice 그리고 apicall 등 설정 그리고 헤더에 로그인한 유저정보를 통해서 이름 불러오기 편의성을 위해 로고에 메인으로 돋보기 옆에 서브메인으로 가기